### PR TITLE
Fixed an issue where a custom font was not displaying in Custom Slides

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -7,9 +7,19 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="952c8f52-4fbc-4a9a-a04b-64cd54717eb6" name="Changes" comment="Fixed a problem where new tags weren't getting numbered.">
+    <list default="true" id="952c8f52-4fbc-4a9a-a04b-64cd54717eb6" name="Changes" comment="Added a check to see if an inserted tag needs line breaks before or after">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/edit_widget.py" beforeDir="false" afterPath="$PROJECT_DIR$/edit_widget.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/README.html" beforeDir="false" afterPath="$PROJECT_DIR$/README.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/ToDo" beforeDir="false" afterPath="$PROJECT_DIR$/ToDo" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/compile_config_and_installers/projecton.iss" beforeDir="false" afterPath="$PROJECT_DIR$/compile_config_and_installers/projecton.iss" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/declarations.py" beforeDir="false" afterPath="$PROJECT_DIR$/declarations.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/main.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/main.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/gui.py" beforeDir="false" afterPath="$PROJECT_DIR$/gui.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/main.py" beforeDir="false" afterPath="$PROJECT_DIR$/main.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/media_widget.py" beforeDir="false" afterPath="$PROJECT_DIR$/media_widget.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/resources/help/intro.html" beforeDir="false" afterPath="$PROJECT_DIR$/resources/help/intro.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/songselect_import.py" beforeDir="false" afterPath="$PROJECT_DIR$/songselect_import.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -70,6 +80,7 @@
     &quot;Python.powerpoint_viewer.executor&quot;: &quot;Debug&quot;,
     &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
     &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
     &quot;git-widget-placeholder&quot;: &quot;development&quot;,
     &quot;ignore.virus.scanning.warn.message&quot;: &quot;true&quot;,
     &quot;last_opened_file_path&quot;: &quot;X:/Documents/Python Workspace/hymn_helper&quot;,
@@ -166,22 +177,6 @@
       <workItem from="1725650345914" duration="5458000" />
       <workItem from="1725983928582" duration="6657000" />
       <workItem from="1725995303841" duration="13965000" />
-    </task>
-    <task id="LOCAL-00065" summary="Set self.main.settings to default_settings in case of JSONDecodeError.&#10;&#10;In GUI.check_files, checked for individual files/directories in case only one got deleted.&#10;&#10;Fixed crash in update_font when creating a new song/custom slide.&#10;&#10;Fixed crash in edit widget when no global background(s) have been chosen or when background image is missing.&#10;&#10;Ensured font widget is re-shown after custom color dialog is done.">
-      <option name="closed" value="true" />
-      <created>1726594201574</created>
-      <option name="number" value="00065" />
-      <option name="presentableId" value="LOCAL-00065" />
-      <option name="project" value="LOCAL" />
-      <updated>1726594201574</updated>
-    </task>
-    <task id="LOCAL-00066" summary="Added backup option to the File menu and applicable code.&#10;Fixed how songs and custom slide data is handled when override global is None or False.">
-      <option name="closed" value="true" />
-      <created>1726690710968</created>
-      <option name="number" value="00066" />
-      <option name="presentableId" value="LOCAL-00066" />
-      <option name="project" value="LOCAL" />
-      <updated>1726690710969</updated>
     </task>
     <task id="LOCAL-00067" summary="Added backup option to the File menu and applicable code.&#10;Fixed how songs and custom slide data is handled when override global is None or False.&#10;Fixed wrong oos item icon on non-override song.">
       <option name="closed" value="true" />
@@ -559,7 +554,23 @@
       <option name="project" value="LOCAL" />
       <updated>1737579221395</updated>
     </task>
-    <option name="localTasksCounter" value="114" />
+    <task id="LOCAL-00114" summary="Added a check to see if an inserted tag needs line breaks before or after">
+      <option name="closed" value="true" />
+      <created>1737653731154</created>
+      <option name="number" value="00114" />
+      <option name="presentableId" value="LOCAL-00114" />
+      <option name="project" value="LOCAL" />
+      <updated>1737653731155</updated>
+    </task>
+    <task id="LOCAL-00115" summary="Added a check to see if an inserted tag needs line breaks before or after">
+      <option name="closed" value="true" />
+      <created>1737653787419</created>
+      <option name="number" value="00115" />
+      <option name="presentableId" value="LOCAL-00115" />
+      <option name="project" value="LOCAL" />
+      <updated>1737653787420</updated>
+    </task>
+    <option name="localTasksCounter" value="116" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -580,7 +591,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Added audio option to custom slides. Needs to be tested against video slides." />
     <MESSAGE value="Added loop option to audio&#10;Changed edit widget audio buttons to icons" />
     <MESSAGE value="Added auto-play option to custom slides. Auto-play parses user's text based on blank lines." />
     <MESSAGE value="Added documentation&#10;Removed default to bold in lyric widget text label" />
@@ -605,7 +615,8 @@
     <MESSAGE value="Added ability to see release notes from About and update dialog" />
     <MESSAGE value="Ensured web remote is getting correct text for each slide" />
     <MESSAGE value="Fixed a problem where new tags weren't getting numbered." />
-    <option name="LAST_COMMIT_MESSAGE" value="Fixed a problem where new tags weren't getting numbered." />
+    <MESSAGE value="Added a check to see if an inserted tag needs line breaks before or after" />
+    <option name="LAST_COMMIT_MESSAGE" value="Added a check to see if an inserted tag needs line breaks before or after" />
   </component>
   <component name="XDebuggerManager">
     <watches-manager>

--- a/README.html
+++ b/README.html
@@ -21,32 +21,17 @@ tech-savvy volunteers. ProjectOn seeks to provide an easy to use,
 intuitive, and responsive experience when building and running the
 projection needs of a church service.</p>
 
-<h1>What's New in Version 1.5.6?</h1>
+<h1>What's New in Version 1.5.7?</h1>
 <ul>
-    <li>Further refined the usage of blank lines when editing songs or custom slides</li>
-    <li>Improved the adding and deleting of tags in the editor</li>
-    <li>Ensured web remote is getting the correct text for each slide</li>
-</ul>
-
-<h1>Other Recent Changes</h1>
-<ul>
-    <li>Fixed a bug with the lyrics when reloading the remote web page.</li>
-    <li>Fixed a little bug that crept in to the Chorus tag on songs.</li>
-    <li>Displayed lyrics/custom slide text now respects blank lines from the editor.</li>
-    <li>Reverted to PyQt5 to fix broken audio and video.</li>
-    <li>Fixed some buggy behavior in the text editor of songs and custom slides.</li>
-    <li>Fixed the theming of context menus.</li>
-    <li>Fixed the auto-scrolling of items in the web remotes.</li>
-    <li>Added the ability to play an audio file along with a custom slide</li>
-    <li>Added the ability to split custom slides into multiple slides as well as auto-play those slides if desired</li>
-    <li>Fixed wrong background showing on some slides</li>
-    <li>Improvements to the way words are shown for music and custom slides</li>
-    <li>Many improvements and bug-fixes under the hood</li>
+    <li>Fixed an issue where a custom font was not displaying in Custom Slides</li>
+    <li>Song search now includes searching each song's lyrics (search terms found in titles appear first in the results)</li>
+    <li>Ensured that, when a custom slide is to be split into individual slides, the split occurs only at the blank lines</li>
+    <li>Fixed an issue with the CCLI song import where the login button was disabled on CCLI's website</li>
 </ul>
 
 <h1 id="installation">Installation</h1>
 <p>Currently, ProjectOn is available for the Microsoft Windows operating
-system only. Download the current ProjectOn installer (v.1.5.6) and run
+system only. Download the current ProjectOn installer (v.1.5.7) and run
 it on your computer.</p>
 
 <h1 id="using-projecton">Using ProjectOn</h1>

--- a/README.md
+++ b/README.md
@@ -10,36 +10,22 @@ ProjectOn is an open-source multimedia projection program geared towards
 producing and running church services.
 
 # Why ProjectOn?
-
 Working in a smaller church, I was limited by a small budget, the small
 number of open-source church projection programs available, and few
 tech-savvy volunteers. ProjectOn seeks to provide an easy to use,
 intuitive, and responsive experience when building and running the
 projection needs of a church service.
 
-# What's New in Version 1.5.6?
-- Further refined the usage of blank lines when editing songs or custom slides 
-- Improved the adding and deleting of tags in the editor
-- Ensured web remote is getting the correct text for each slide
-
-# Other Recent Changes
-- Fixed a bug with the lyrics when reloading the remote web page.
-- Fixed a little bug that crept in to the Chorus tag on songs.
-- Displayed lyrics/custom slide text now respects blank lines from the editor.
-- Reverted to PyQt5 to fix broken audio and video.
-- Fixed some buggy behavior in the text editor of songs and custom slides.
-- Fixed the theming of context menus.
-- Fixed the auto-scrolling of items in the web remotes.
-- Added the ability to play an audio file along with a custom slide
-- Added the ability to split custom slides into multiple slides as well as auto-play those slides if desired
-- Fixed wrong background showing on some slides
-- Improvements to the way words are shown for music and custom slides
-- Many improvements and bug-fixes under the hood
+# What's New in Version 1.5.7?
+- Fixed an issue where a custom font was not displaying in Custom Slides
+- Song search now includes searching each song's lyrics (search terms found in titles appear first in the results)
+- Ensured that, when a custom slide is to be split into individual slides, the split occurs only at the blank lines
+- Fixed an issue with the CCLI song import where the login button was disabled on CCLI's website
 
 # Installation
 
 Currently, ProjectOn is available for the Microsoft Windows operating
-system only. Download the current ProjectOn installer (v.1.5.6) and run
+system only. Download the current ProjectOn installer (v.1.5.7) and run
 it on your computer.
 
 # Using ProjectOn
@@ -140,7 +126,7 @@ size of the font that appears on the Stage View.
 In the Global Background section you can choose the default background
 for songs and for bible passages. These changes can also be made in the
 toolbar at the top of the main window. Songs and bible verses will
-automatically used these backgrounds, unless you specify a custom
+automatically use these backgrounds, unless you specify a custom
 background to use when editing a song.
 
 Here, too, you can choose a custom “Logo” image to display when nothing

--- a/ToDo
+++ b/ToDo
@@ -1,9 +1,11 @@
 Done:
-    Further refined the usage of blank lines when editing songs or custom slides
-    Improved the adding and deleting of tags in the editor
-    Ensured web remote is getting the correct text for each slide
+    Custom font in Custom Slides
+    Search songs - include words
+    Split Slides - split at double enter
+    CCLI Login Greyed Out
 
 Future Releases:
+    Standardize parsed_text - title - text across all slide types
     Import slide audio to data folder
     Video backgrounds
     Further consolidate widgets

--- a/compile_config_and_installers/projecton.iss
+++ b/compile_config_and_installers/projecton.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "ProjectOn"
-#define MyAppVersion "1.5.6"
+#define MyAppVersion "1.5.7"
 #define MyAppPublisher "Wilson's Widgets"
 #define MyAppExeName "ProjectOn.exe"
 #define MyAppAssocName MyAppName + " File"

--- a/declarations.py
+++ b/declarations.py
@@ -119,7 +119,7 @@ SQL_COLUMN_TO_DICTIONARY_SONG = {
 SQL_COLUMN_TO_DICTIONARY_CUSTOM = {
     0: 'title',
     1: 'text',
-    2: 'font',
+    2: 'font_family',
     3: 'font_color',
     4: 'background',
     5: 'font_size',

--- a/docs/main.html
+++ b/docs/main.html
@@ -11,7 +11,7 @@
 ><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/jeremy/Documents/Python%20Workspace/project_on/main.py">/home/jeremy/Documents/Python Workspace/project_on/main.py</a></font></td></tr></table>
     <p><tt>This&nbsp;file&nbsp;and&nbsp;all&nbsp;files&nbsp;contained&nbsp;within&nbsp;this&nbsp;distribution&nbsp;are&nbsp;parts&nbsp;of&nbsp;the&nbsp;<a href="#ProjectOn">ProjectOn</a>&nbsp;worship&nbsp;projection&nbsp;software.<br>
 &nbsp;<br>
-<a href="#ProjectOn">ProjectOn</a>&nbsp;v.1.5.6<br>
+<a href="#ProjectOn">ProjectOn</a>&nbsp;v.1.5.7<br>
 Written&nbsp;by&nbsp;Jeremy&nbsp;G&nbsp;Wilson<br>
 &nbsp;<br>
 <a href="#ProjectOn">ProjectOn</a>&nbsp;is&nbsp;free&nbsp;software:&nbsp;you&nbsp;can&nbsp;redistribute&nbsp;it&nbsp;and/or<br>

--- a/gui.py
+++ b/gui.py
@@ -594,7 +594,7 @@ class GUI(QObject):
             wait_widget.widget.deleteLater()
 
     def check_update(self):
-        current_version = 'v.1.5.6'
+        current_version = 'v.1.5.7'
         current_version = current_version.replace('v.', '')
         current_version = current_version.replace('rc', '')
         current_version_split = current_version.split('.')
@@ -838,7 +838,7 @@ class GUI(QObject):
         title_pixmap_label.setPixmap(title_pixmap)
         title_widget.layout().addWidget(title_pixmap_label)
 
-        title_label = QLabel('ProjectOn v.1.5.6')
+        title_label = QLabel('ProjectOn v.1.5.7')
         title_label.setFont(QFont('Helvetica', 24, QFont.Weight.Bold))
         title_widget.layout().addWidget(title_label)
         title_widget.layout().addStretch()
@@ -1256,10 +1256,9 @@ class GUI(QObject):
             slide_text = slide_data['text']
             if (slide_data['split_slides']
                     and slide_data['split_slides'] == 'True'):
-                slide_text = re.sub('<p.*?>', '', slide_text)
-                slide_text = re.sub('</p>', '', slide_text)
-                slide_text = re.sub('(<br />)+', '\n', slide_text)
-                slide_data['parsed_text'] = re.split('\n', slide_text)
+                slide_text = re.sub(r'(<br />)\1+', '<split>', slide_text)
+                print(slide_text)
+                slide_data['parsed_text'] = re.split('<split>', slide_text)
             else:
                 slide_data['parsed_text'] = [slide_text]
             item.setData(Qt.ItemDataRole.UserRole, slide_data)
@@ -1625,6 +1624,7 @@ class GUI(QObject):
 
             # set the font
             if 'override_global' in item_data.keys() and item_data['override_global'] == 'True':
+                print(json.dumps(item_data, indent=4))
                 font_face = item_data['font_family']
                 font_size = int(item_data['font_size'])
                 font_color = item_data['font_color']

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """
 This file and all files contained within this distribution are parts of the ProjectOn worship projection software.
 
-ProjectOn v.1.5.6
+ProjectOn v.1.5.7
 Written by Jeremy G Wilson
 
 ProjectOn is free software: you can redistribute it and/or
@@ -169,7 +169,7 @@ class ProjectOn(QObject):
                 160, 160, Qt.AspectRatioMode.IgnoreAspectRatio, Qt.TransformationMode.SmoothTransformation))
         icon_layout.addWidget(icon_label)
 
-        version_label = QLabel('v.1.5.6')
+        version_label = QLabel('v.1.5.7')
         version_label.setStyleSheet('color: white')
         version_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         icon_layout.addWidget(version_label, Qt.AlignmentFlag.AlignCenter)

--- a/media_widget.py
+++ b/media_widget.py
@@ -34,6 +34,7 @@ class MediaWidget(QTabWidget):
         self.setFont(self.gui.standard_font)
         self.setObjectName('media_widget')
         self.setTabShape(QTabWidget.TabShape.Rounded)
+        self.song_list_items = []
 
         self.formatted_reference = None
 
@@ -443,14 +444,28 @@ class MediaWidget(QTabWidget):
         Method that retrieves the current text in the song widget's search_line_edit and shows/hides songs that do or
         don't contain the text.
         """
-        search_string = self.search_line_edit.text().lower()
+        self.song_list.clear()
+        search_string = self.search_line_edit.text().strip().lower()
+        if len(search_string) == 0:
+            for item in self.song_list_items:
+                self.song_list.addItem(item.clone())
+            return
 
-        for i in reversed(range(self.song_list.count())):
-            if self.song_list.item(i):
-                self.song_list.item(i).setHidden(False)
-                song_title = self.song_list.item(i).text().lower()
-                if search_string not in song_title:
-                    self.song_list.item(i).setHidden(True)
+        show_list_items = []
+        show_list_indices = []
+        for i in range(len(self.song_list_items)):
+            if search_string in self.song_list_items[i].data(Qt.ItemDataRole.UserRole)['title'].strip().lower():
+                #print(f'search string found in {self.song_list_items[i][1]}')
+                show_list_items.append(self.song_list_items[i].clone())
+                show_list_indices.append(i)
+
+        for i in range(len(self.song_list_items)):
+            if search_string in self.song_list_items[i].data(Qt.ItemDataRole.UserRole)['text'].strip().lower() and i not in show_list_indices:
+                #print(f'search string found in {self.song_list_search_index[i][1]}\'s lyrics')
+                show_list_items.append(self.song_list_items[i].clone())
+
+        for item in show_list_items:
+            self.song_list.addItem(item)
 
     def populate_song_list(self):
         """
@@ -472,7 +487,8 @@ class MediaWidget(QTabWidget):
                 list_item = QListWidgetItem(slide_data['title'])
                 list_item.setData(Qt.ItemDataRole.UserRole, slide_data)
 
-                self.song_list.addItem(list_item)
+                self.song_list_items.append(list_item)
+                self.song_list.addItem(list_item.clone())
 
     def populate_custom_list(self):
         """

--- a/resources/help/intro.html
+++ b/resources/help/intro.html
@@ -15,7 +15,7 @@
     <p>Use the tabs at the top of this window to view the different help topics.</p>
     <hr>
     <h2>Boring Stuff:</h2>
-    <p>This is version 1.5.6 of ProjectOn</p>
+    <p>This is version 1.5.7 of ProjectOn</p>
     <p>ProjectOn is free software: you can redistribute it and/or
     modify it under the terms of the GNU General Public License (GNU GPL)
     published by the Free Software Foundation, either version 3 of the

--- a/songselect_import.py
+++ b/songselect_import.py
@@ -16,8 +16,7 @@ from simple_splash import SimpleSplash
 
 class SongselectImport(QDialog):
     BASE_URL = 'https://songselect.ccli.com'
-    LOGIN_PAGE = ('https://profile.ccli.com/Account/Signin?'
-                  'appContext=SongSelect&returnUrl=https%3A%2F%2Fsongselect.ccli.com%2F')
+    LOGIN_PAGE = ('https://profile.ccli.com/Account/Signin?appContext=SongSelect&returnUrl=https://songselect.ccli.com/&data-callback=enableSubmit')
     LOGIN_URL = 'https://profile.ccli.com'
     LOGOUT_URL = BASE_URL + '/account/logout'
     SEARCH_URL = BASE_URL + '/search/results'
@@ -203,7 +202,8 @@ class SongselectImport(QDialog):
             user_name, password = self.store_credentials()
 
         if not user_name == -1:
-            script_set_login_fields = ('document.getElementById("EmailAddress").value = "{user_name}";'
+            script_set_login_fields = ('document.getElementById("sign-in").disabled = false;'
+                                       'document.getElementById("EmailAddress").value = "{user_name}";'
                                        'document.getElementById("Password").value = "{password}";'
                                        'document.getElementById("sign-in").click();'
                                        ).format(user_name=user_name, password=password)


### PR DESCRIPTION
Song search now includes searching each song's lyrics (search terms found in titles appear first in the results) 

Ensured that, when a custom slide is to be split into individual slides, the split occurs only at the blank lines 

Fixed an issue with the CCLI song import where the login button was disabled on CCLI's website